### PR TITLE
expose SchemaError in init

### DIFF
--- a/xarray_schema/__init__.py
+++ b/xarray_schema/__init__.py
@@ -1,5 +1,6 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
+from .base import SchemaError  # noqa: F401
 from .components import (  # noqa: F401
     ArrayTypeSchema,
     ChunksSchema,


### PR DESCRIPTION
this allows usage such as `from xarray_schema import SchemaError` instead of `from xarray_schema.base import SchemaError`