### PR TITLE
Remove deprecated `pkg_resources`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=xarray_schema
-known_third_party=dask,invoke,jsonschema,numpy,pkg_resources,pytest,setuptools,xarray
+known_third_party=dask,invoke,jsonschema,numpy,pytest,setuptools,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/xarray_schema/__init__.py
+++ b/xarray_schema/__init__.py
@@ -1,4 +1,4 @@
-from pkg_resources import DistributionNotFound, get_distribution
+import importlib.metadata
 
 from .base import SchemaError  # noqa: F401
 from .components import (  # noqa: F401
@@ -14,8 +14,4 @@ from .components import (  # noqa: F401
 from .dataarray import CoordsSchema, DataArraySchema  # noqa: F401
 from .dataset import DatasetSchema  # noqa: F401
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # noqa: F401; pragma: no cover
-    # package is not installed
-    pass
+__version__ = importlib.metadata.version("xarray-schema")

--- a/xarray_schema/__init__.py
+++ b/xarray_schema/__init__.py
@@ -14,4 +14,4 @@ from .components import (  # noqa: F401
 from .dataarray import CoordsSchema, DataArraySchema  # noqa: F401
 from .dataset import DatasetSchema  # noqa: F401
 
-__version__ = importlib.metadata.version("xarray-schema")
+__version__ = importlib.metadata.version('xarray-schema')


### PR DESCRIPTION
As mentioned in #193, `pkg_resources` is deprecated and no longer supported.

This PR aims to replace it with `importlib`. Would it be possible to make a new version based on this? Since `xarray-schema` can't be imported on recent Python setups / in certain Docker images.